### PR TITLE
Kleine issues in server fix

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,14 +35,14 @@ const slugFilter = "?filter[slug][_eq]=";
 // Home
 app.get("/", async function (req, res) {
   // req + res plss T-T
-  response.render("index.liquid");
+  res.render("index.liquid");
 });
 
 // webinars
 
 app.get("/webinars", async (req, res) => {
   const webinarsDetailResponse = await fetch(
-    `${webinarsEndpoint}${"webinars?fields=*,speakers.*.*,resources.*.*,categories.*.*"}`
+    `${webinarsEndpoint}?fields=*,speakers.*.*,resources.*.*,categories.*.*`
   );
   const { data: webinarsDetailResponseJson } =
     await webinarsDetailResponse.json();
@@ -83,7 +83,7 @@ app.get("/contourings/:slug", async (req, res) => {
   const { data: contouringsDetailResponseJSON } =
     await contouringsDetailResponse.json();
 
-  response.render("contourings-detail.liquid", {
+  res.render("contourings-detail.liquid", {
     contourings: contouringsDetailResponseJSON,
   });
 });


### PR DESCRIPTION
## Wat is er veranderd? 
Zie #34 
- Er stond nog een paar keer `response` ipv `res`. Dit is nu aangepast. 
- De fetch link naar de webinar detail response had een dubbele `/webinars`. Dit is nu aangepast.

![image](https://github.com/user-attachments/assets/fe9448fe-2e5e-4bec-819d-b55b0eec4e06)
