### PR TITLE
Speaker page

### DIFF
--- a/public/styles/header.css
+++ b/public/styles/header.css
@@ -78,6 +78,7 @@
 
                     svg path {
                         fill: #fff;
+                        transition: 0.2s ease-in-out;
                     }
 
                     &:hover svg path {
@@ -90,7 +91,6 @@
 
                     &:hover {
                         color: var(--primary-highlight);
-                        transition: 0.2s ease-in-out;
                     }
 
                     svg {

--- a/public/styles/speakers.css
+++ b/public/styles/speakers.css
@@ -45,10 +45,13 @@ button {
     gap: 2rem;
     width: 85vw;
     margin: 0 auto;
+    padding: 2rem 0 5rem 0;
+    position: relative;
 }
 
 /* MARK: Speakers introduction */
 .speakers-introduction {
+    position: relative; 
     .speakers-section-title {
         h1 {
             margin: 0 0 1rem 0;
@@ -56,6 +59,16 @@ button {
     }
     .speakers-introduction-description {
         max-width: 575px;
+    }
+    .breadcrumbs-speakers {
+        padding: 1rem 0;
+        li {
+            list-style-type: none;
+    
+            &:first-of-type {
+                font-weight: bold; 
+            }
+        }
     }
 }
 
@@ -108,8 +121,8 @@ button {
 /* MARK: Speakers overview */
 .speakers-container {
     width: 100%;
-    flex-direction: row;
-    flex-wrap: wrap;
+    display: grid; 
+    grid-template-columns: repeat(auto-fill, minmax(20em, 1fr));
     container-type: inline-size;
     container-name: speaker-card; 
 }

--- a/views/partials/speaker-card.liquid
+++ b/views/partials/speaker-card.liquid
@@ -1,7 +1,41 @@
 <article class="speaker-card components-alignment-vertical">
     <div class="speaker-card-main components-alignment-horizontal">
         <div class="speaker-card-profile-picture">
-            <img src="https://fdnd-agency.directus.app/assets/{{ speaker.profile_picture }}" alt="" width="200" height="200" style="object-fit:cover;">
+            <!-- picture element voor responsive images -->
+            <!-- in srcset worden afbeeldingen ingeladen van verschillende formats en breedtes -->
+            <!-- in sizes wordt breedte gekozen en afbeelding geselecteerd -->
+            <picture>
+                <source
+                    srcset="
+                        https://fdnd-agency.directus.app/assets/{{ speaker.profile_picture }}?format=avif&width=50&height=50 50w,   
+                        https://fdnd-agency.directus.app/assets/{{ speaker.profile_picture }}?format=avif&width=100&height=100 100w,   
+                        https://fdnd-agency.directus.app/assets/{{ speaker.profile_picture }}?format=avif&width=200&height=200 200w,   
+                        https://fdnd-agency.directus.app/assets/{{ speaker.profile_picture }}?format=avif&width=300&height=300 300w   
+                    "
+                    sizes="
+                        (max-width: 50px) 50px,
+                        (max-width: 100px) 100px,
+                        (max-width: 200px) 200px,
+                        (max-width: 300px) 300px
+                    "
+                />
+                <source
+                    srcset="
+                        https://fdnd-agency.directus.app/assets/{{ speaker.profile_picture }}?format=webp&width=50&height=50 50w,   
+                        https://fdnd-agency.directus.app/assets/{{ speaker.profile_picture }}?format=webp&width=100&height=100 100w,   
+                        https://fdnd-agency.directus.app/assets/{{ speaker.profile_picture }}?format=webp&width=200&height=200 200w,   
+                        https://fdnd-agency.directus.app/assets/{{ speaker.profile_picture }}?format=webp&width=300&height=300 300w   
+                    "
+                    sizes="
+                        (max-width: 50px) 50px,
+                        (max-width: 100px) 100px,
+                        (max-width: 200px) 200px,
+                        (max-width: 300px) 300px
+                    "
+                />     
+                <!-- fallback image met goed ondersteund format (jpg) -->           
+                <img src="https://fdnd-agency.directus.app/assets/{{ speaker.profile_picture }}?format=jpg" alt="" width="200" height="200" style="object-fit:cover;">
+            </picture>
         </div>
         <div class="speaker-card-name-entitle">
             <h3>{{ speaker.fullname }}</h3>

--- a/views/speakers.liquid
+++ b/views/speakers.liquid
@@ -4,6 +4,10 @@
     <main class="main-speakers components-alignment-vertical">
         <section class="speakers-introduction">
             <div class="speakers-section-title">
+                <ul class="breadcrumbs-speakers components-alignment-horizontal">
+                    <li><a href="/">Home &rsaquo;</a></li>
+                    <li><a href="/speakers">Speakers</a></li>
+                </ul>
                 <h1>Speakers</h1>
             </div>
             <div class="speakers-introduction-description">


### PR DESCRIPTION
## Wat is er veranderd? 
Ik heb gewerkt aan #48 en #6

Op de speaker pagina heb ik de breadcrumbs toegevoegd en wat styling veranderd, zoals een `grid` met `autofit` ipv een `flex` met `flex-wrap`. 

Ook viel me op dat bij de `header` en `footer` de transition van de tekst en de `svg`s niet gelijk liep, dus dit heb ik ook opgelost. 

## Visuals

https://github.com/user-attachments/assets/55efd303-3164-4f39-98b4-6f502b293244