### PR TITLE
Scroll driven animation cards

### DIFF
--- a/public/styles/scroll-driven-cards.css
+++ b/public/styles/scroll-driven-cards.css
@@ -1,0 +1,15 @@
+@media (prefers-reduced-motion: no-preference) {
+    .speakers-container article, .webinar-cards li {
+        animation: linear animate-in;
+        animation-timeline: view();
+    }
+}
+
+@keyframes animate-in {
+    entry 0%  {
+        opacity: 0; transform: translateY(100%);
+    }
+    entry 100%  {
+        opacity: 1; transform: translateY(0);
+    }
+}

--- a/public/styles/scroll-driven-cards.css
+++ b/public/styles/scroll-driven-cards.css
@@ -1,7 +1,9 @@
-@media (prefers-reduced-motion: no-preference) {
-    .speakers-container article, .webinar-cards li {
-        animation: linear animate-in;
-        animation-timeline: view();
+@supports (animation-timeline: view()) {
+    @media (prefers-reduced-motion: no-preference) {
+        .speakers-container article, .webinar-cards li {
+            animation: linear animate-in;
+            animation-timeline: view();
+        }
     }
 }
 

--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -7,3 +7,4 @@
 @import url("speaker-detail.css");
 @import url("webinar-detail.css");
 @import url("home.css");
+@import url("scroll-driven-cards.css")


### PR DESCRIPTION
## Wat is er veranderd? 
Ik wilde experimenteren met scroll driven animations in CSS en het leek me goed idee om dit toe te passen op de webinar en speaker cards. 

Ik heb een nieuw CSS bestand aangemaakt en hierin met `animation-timeline: view()` en `@keyframes` met `entry` de cards geanimeerd mij het scrollen van de pagina. Deze functies zijn genest in een `@supports` en `prefers-reduced-motion: no-preference`

N.B. bij de visuals zie je bij desktop de cards nog in een lage opacity op het scherm, dit is omdat de styling van deze pagina in deze branch nog op orde is. Wanneer de styling vanuit de speaker branch gemerged kan worden, zie je de cards pas bij het beginnen met scrollen. 

## Visuals
### Mobiel (bv webinars)
https://github.com/user-attachments/assets/1c626631-5804-4aca-9f02-8039ab264406

### Dekstop (bv speakers)
https://github.com/user-attachments/assets/c3398bc1-76b3-4b07-93f6-68cb4b928d72