### PR TITLE
Toggle header/footer bij scrollen

### DIFF
--- a/public/script-page-scroll.js
+++ b/public/script-page-scroll.js
@@ -1,0 +1,17 @@
+const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      const intersecting = entry.isIntersecting
+      
+      if (!intersecting) {
+        document.documentElement.classList.add("offscreen")
+      }
+      
+      if (intersecting) {
+        document.documentElement.classList.remove("offscreen")
+      }
+    })
+})
+  
+let header = document.querySelector("header")
+  
+observer.observe(header)

--- a/public/styles/page-scroll.css
+++ b/public/styles/page-scroll.css
@@ -1,12 +1,14 @@
-@media (max-width: 1020px) {
-    .main-header .menu {
-        position: fixed; 
-        bottom: 0; 
-        translate: 0 100%;
-        transition: .3s ease-out; 
-    }
-    
-    .offscreen .main-header .menu {
-        translate: 0% 0%;
+@media (prefers-reduced-motion: no-preference) {
+    @media (max-width: 1020px) {
+        .main-header .menu {
+            position: fixed; 
+            bottom: 0; 
+            translate: 0 100%;
+            transition: .3s ease-out; 
+        }
+        
+        .offscreen .main-header .menu {
+            translate: 0% 0%;
+        }
     }
 }

--- a/public/styles/page-scroll.css
+++ b/public/styles/page-scroll.css
@@ -1,10 +1,12 @@
-.main-header .menu {
-    position: fixed; 
-    bottom: 0; 
-    translate: 0 100%;
-    transition: .3s ease-out; 
-}
-
-.offscreen .main-header .menu {
-    translate: 0% 0%;
+@media (max-width: 1020px) {
+    .main-header .menu {
+        position: fixed; 
+        bottom: 0; 
+        translate: 0 100%;
+        transition: .3s ease-out; 
+    }
+    
+    .offscreen .main-header .menu {
+        translate: 0% 0%;
+    }
 }

--- a/public/styles/page-scroll.css
+++ b/public/styles/page-scroll.css
@@ -1,0 +1,10 @@
+.main-header .menu {
+    position: fixed; 
+    bottom: 0; 
+    translate: 0 100%;
+    transition: .3s ease-out; 
+}
+
+.offscreen .main-header .menu {
+    translate: 0% 0%;
+}

--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -7,3 +7,4 @@
 @import url("speaker-detail.css");
 @import url("webinar-detail.css");
 @import url("home.css");
+@import url("page-scroll.css");

--- a/views/partials/foot.liquid
+++ b/views/partials/foot.liquid
@@ -47,6 +47,8 @@
     </div>
 </footer>
 
+<script src="/script-page-scroll.js"></script>
+
 </body>
 
 </html>


### PR DESCRIPTION
## Wat is er veranderd? 
### Issue
Zie issue #49 Pleasurable UI

[Zie Figma](https://www.figma.com/design/BfNlwlghQo4GKty5b9saOC/Oncollaboration?node-id=341-2&t=GltfAx0QwAWKYBmp-1) voor het ontwerp 

### Wat heb ik gemaakt? 
In bovenstaanden issue werk ik aan verschillende animaties en andere enhancements op de UI te verbeteren. In deze branch heb ik gewerkt aan het verbergen/tonen van de `footer` op basis van scrollen en de zichtbaarheid van de `header`. Dit is allemaal voor mobiel. 

De `header` heeft een `relative` positie op het scherm, wanneer deze uit beeld verdwijnt (door te scrollen), komt de `footer` tevoorschijn met een `fixed` positie. Als de header vervolgens weer in beeld is, verdwijnt de `footer`. 

### Ontwerpkeuzes
De `header` en `footer` zijn al eerder gemaakt. Ik vond het verder belangrijk dat niet zowel de `header` als `footer` in het beeld blijven staan met een `fixed` positie, omdat dit veel oppervlakte van het scherm in neemt. Daarom verdwijnt de `footer` als de `header` in beeld is, en komt de `footer` in beeld als de `header` in beeld is. 

#### Hierarchy of User Needs 
##### Functional 
De functionaliteit is al eerder gebouwd door een ander teamlid

##### Reliable 
De functionaliteit is al eerder gebouwd door een ander teamlid

##### Usable 
Deze toggle functie is een enhancement. Wanneer JS bijvoorbeeld uitgeschakeld is, dan komen zijn de `header` en `footer` normaal te gebruiken, zonder transition.

##### Pleasurable 
In deze laag komt de enhancement kijken. Met JS zorg ik er dus voor dat de header/footer getoggled worden en in/buiten beeld komen te staan. 

### Hoe heb je rekening gehouden met een RAPPE website? 
#### Responsive
Deze functie is gebouwd voor de mobiele layout. Vanaf 1020px verdwijnt de footer met knoppen onderaan het scherm, en wordt dit in de `header` toegevoegd. Ik heb dus een `@media` geschreven om hier rekening mee te houden. 

#### Accessible
In CSS heb ik alle code rondom deze functie in een `prefers-reduced-motion: no-preference` gezet, zodat deze functie  alleen toegepast wordt als de gebruiker dit niet uitgeschakeld heeft. 

#### Performance 
n.v.t. 

#### Progressively enhanced
Met JS zorg ik er dus voor dat de header/footer getoggled worden en in/buiten beeld komen te staan. Deze toggle functie is een enhancement. Wanneer JS bijvoorbeeld uitgeschakeld is, dan komen zijn de `header` en `footer` normaal te gebruiken, zonder transition. 

### Feedback 
Wat vinden jullie? Is het misschien beter om de `footer` altijd in beeld te laten staan, wanneer deze eenmaal getriggered wordt door scrollen of juist prettig om óf de `header` te laten zien óf de `footer`? 

## Visuals
https://github.com/user-attachments/assets/8bd22709-f24b-401c-bb57-dea3b2f9d6ca



