### PR TITLE
Custom select & animation

### DIFF
--- a/public/styles/filter-animation.css
+++ b/public/styles/filter-animation.css
@@ -1,0 +1,101 @@
+html {
+    interpolate-size: allow-keywords; 
+}
+
+select {
+    background-color: var(--secondary-light);
+    color: var(--primary-dark);
+    font-family: var(--font-paragraph);
+    font-size: var(--border-radius-md);
+    padding: var(--padding-button);
+    border-radius: var(--border-radius-sm);
+    transition: 0.2s ease-in-out;
+    align-items: center;
+    cursor: pointer;
+}
+
+.speakers-filter select:open {
+    margin-bottom: 5.5rem;
+}
+
+::picker(select) {
+    position-area: buttom; 
+    margin-top: .5em;
+    border-radius: .5em;
+
+    height: 0;
+    min-height: 0; 
+    transition: 
+        height .3s, 
+        display .3s allow-discrete, 
+        overlay .3s allow-discrete; 
+    overflow: clip; 
+    position-try-fallbacks: unset; 
+}
+
+/* SELECT & PICKERS */
+select, ::picker(select) {
+    appearance: base-select;
+}
+  
+/* PICKER icon */
+::picker-icon {
+content: "";
+width: .5em;
+height: .5em;
+background-color: currentcolor;
+clip-path: polygon(0 .1em, 100% .1em, 50% 100%, 0 .1em);
+transition: .3s;
+}
+
+/* SELECT OPTION */
+select option {
+    background-color: var(--primary-dark);
+    color: var(--secondary-light);
+    padding: var(--padding-button);
+    transition: .3s ease-out;
+
+    &:hover {
+        background-color: var(--primary-highlight);
+        color: var(--primary-dark);
+    }
+}
+
+/* SELECT open */
+
+/* PICKER */
+select:open::picker(select) {
+height:auto;	
+
+    @starting-style {
+        height:0;
+    }
+}
+
+/* PICKER ICON */
+select:open::picker-icon {
+    rotate:x 180deg;
+}
+
+/* OPTION */
+select:open option{
+    @media (prefers-reduced-motion:no-preference) {
+        transition:
+        opacity .5s calc( (sibling-index() - 1) * .075s ),
+        translate 1s calc( (sibling-index() - 1) * .075s );
+    }
+
+    @starting-style {
+        opacity:0;
+        translate:-500% 0%;
+    }  
+}
+
+option:checked {
+    background-color: white;
+    color: var(--primary-dark);
+}
+
+option::checkmark {
+    display: none; 
+}

--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -7,3 +7,4 @@
 @import url("speaker-detail.css");
 @import url("webinar-detail.css");
 @import url("home.css");
+@import url("filter-animation.css")

--- a/views/speakers.liquid
+++ b/views/speakers.liquid
@@ -16,15 +16,33 @@
                 <h2>Filter</h2>
             </div>
 
+            {% comment %} <form>
+                <label for="filter">Filter webinars</label>
+                
+                <select id="filter">
+                    <button>
+                    <selectedcontent></selectedcontent>
+                    </button>
+                    
+                    <option value="Head-Neck">Head & Neck</option>
+                    <option value="Lungs">Lungs</option>
+                    <option value="Skin">Skin</option>
+                </select>
+            </form> {% endcomment %}
+
             <!-- Filter formulier -->
             <form class="speakers-filter">
-                <label>
+                <label for="speakers-filter">
                     View all speakers or use the filter to view your bookmarked speakers.
-                    <select name="filter">
+                </label>
+                
+                    <select id="filter">
+                        <button>
+                            <selectedcontent></selectedcontent>
+                        </button>
                         <option value="all">All</option>
                         <option value="bookmarked-speakers">Bookmarked speakers</option>
                     </select>
-                </label>
                 <button type="submit" class="speakers-submit button-green">Filter speakers</button>
             </form>
         </section>


### PR DESCRIPTION
## Wat is er veranderd? 
Zie issue #49 Pleasurable UI

Ik heb gewerkt aan de custom `select` (stylen in de huisstijl) en heb hierbij zowel de `option`s geanimeerd en het openen/sluiten van het menu. Ik heb dit toegepast op de filters bij de `/webinars` en bij de `/speakers`.

Wat vinden jullie van de animaties en van de states (actief = wit, hover = groen)? 

## Visuals
### Webinars

https://github.com/user-attachments/assets/bd75126c-ac90-4dc2-9921-64bb7d143e72

### Webinars mobiel 

https://github.com/user-attachments/assets/12332aa7-52f9-40a6-8131-e435f4782ecf

### Speakers

https://github.com/user-attachments/assets/277dc5c2-8253-4cb4-a914-f0bcd0660ce7


