### PR TITLE
Performance test webinars

### DIFF
--- a/views/partials/webinar-card.liquid
+++ b/views/partials/webinar-card.liquid
@@ -2,9 +2,33 @@
     {% for webinar in webinars %}
     <li class="card">
         <div class="wrapper-card">
-            <img class="banner"
-                src="https://fdnd-agency.directus.app/assets/{{ webinar.thumbnail }}?width=450&height=338&fit=cover"
-                alt="{{ webinar.title }}" width="350" height="300">
+            <picture>
+                <source srcset="
+                                    https://fdnd-agency.directus.app/assets/{{ webinar.thumbnail }}?format=avif&width=150 150w,
+                                    https://fdnd-agency.directus.app/assets/{{ webinar.thumbnail }}?format=avif&width=250 250w,
+                                    https://fdnd-agency.directus.app/assets/{{ webinar.thumbnail }}?format=avif&width=350 350w,
+                                    https://fdnd-agency.directus.app/assets/{{ webinar.thumbnail }}?format=avif&width=400 400w"
+                    type="
+                                    image/avif" sizes="
+                                    (max-width: 150px) 150px,
+                                    (max-width: 250px) 250px,
+                                    (max-width: 350px) 350px,
+                                    (min-width: 400px) 400px">
+                <source srcset="
+                                    https://fdnd-agency.directus.app/assets/{{ webinar.thumbnail }}?format=webp&width=150 150w,
+                                    https://fdnd-agency.directus.app/assets/{{ webinar.thumbnail }}?format=webp&width=250 250w,
+                                    https://fdnd-agency.directus.app/assets/{{ webinar.thumbnail }}?format=webp&width=350 350w,
+                                    https://fdnd-agency.directus.app/assets/{{ webinar.thumbnail }}?format=webp&width=400 400w"
+                    type="
+                                    image/webp" sizes="
+                                    (max-width: 150px) 150px,
+                                    (max-width: 250px) 250px,
+                                    (max-width: 350px) 350px,
+                                    (min-width: 400px) 400px">
+                <img class="banner"
+                    src="https://fdnd-agency.directus.app/assets/{{ webinar.thumbnail }}?width=450&height=338&fit=cover"
+                    alt="{{ webinar.title }}" width="350" height="300">
+            </picture>
             <p class="duration">{{ webinar.duration }}</p>
             {% assign webinarIdString = webinar.id | string | strip %}
             <form class="bookmark-webinar-form" method="POST" action="/webinars" data-enhanced="form-{{ webinar.id}}">

--- a/views/partials/webinar-card.liquid
+++ b/views/partials/webinar-card.liquid
@@ -60,7 +60,7 @@
                 {{ speaker.avl_speakers_id.fullname }}
                 {% endfor %}
             </p>
-            <a href="/webinars/{{ webinar.slug }}">View webinar<img src="/assets-webinars/icon-arrow-right.svg"
+            <a href="/webinars/{{ webinar.slug }}">View webinar<img src="/assets-webinars/icon-arrow-right.svg" width="25" height="25"
                     alt=""></a>
         </section>
     </li>


### PR DESCRIPTION
## Wat is er veranderd?
De webinars pagina heb ik getest op performance. Ik heb een lighthouse Performance test uitgevoerd. In de issue #46 heb ik de resultaten van de test gedocumenteerd en opgelost, dit is te zien aan de hand van de commits.

### Het volgende is er veranderd:
- De banner img in de webinar cards zijn nu responsive aan de hand van een `<picture>` element met een `srcset`. De afbeeldingen zijn aan de hand van `max-width en min-width` gekoppeld aan een width en height zodat het juiste formaat afbeelding wordt geladen op het juiste schermformaat.
- De banner img formaat omgezet naar `avif` met als fallback `webp` en `jpeg`.
- De arrow icons in de webinar cards hebben een `width` en `height` attribuut meegekregen.

Al deze punten voorkomen layout shifts en een lange laadtijd.

### Rappe website onderbouwing
**Responsive:** de Lighthouse Performance is zowel op mobiel als desktop getest.
**Accessibility:** Door het voorkomen van layout shifts blijven interactieve elementen verschuiven deze bij het laden niet van plek wat misklikken voorkomt.
**Progressive enhancement:** n.v.t

### Ontwerpkeuzes

Ontwerpkeuzes zijn bij deze veranderingen/aanpassingen niet van toepassing.

### Waar wil ik feedback op?
Ik zou graag feedback willen op de code van de responsive banner afbeelding. Heb ik de code op juiste manier toegepast?

## Visuals

<img width="1305" alt="image" src="https://github.com/user-attachments/assets/9ccbdedd-47d1-4fa7-b356-3ccd8ce196e9" />
